### PR TITLE
Approach 1: Removing autoprefixer

### DIFF
--- a/gen/script.go
+++ b/gen/script.go
@@ -570,7 +570,6 @@ func (s *Script) addSass(_, dir string) {
 	for _, n := range []string{
 		"node-sass",
 		"postcss-cli",
-		"autoprefixer",
 		"clean-css-cli",
 		"deasync",
 	} {
@@ -653,7 +652,6 @@ func (s *Script) addSass(_, dir string) {
 			err = runSilent(
 				s.flags,
 				"postcss",
-				"--use=autoprefixer",
 				"--map",
 				"--output="+filepath.Join(s.flags.Build, cssDir, fn+".postcss.css"),
 				filepath.Join(s.flags.Build, cssDir, fn+".css"),


### PR DESCRIPTION
By removing the `--use` flag in the postcss step, it will be able to pick up a `postcss.config.js` file in the projects root directory.
The config file can define several plugins to be used.

The rest of the build steps are unaffected.

#### Feature parity
To maintain feature parity with the current build process, we would only need to add a postcss config file:

```
module.exports = {
  plugins: [require("autoprefixer")],
};
```

#### Tailwind & PurgeCSS
To enable Tailwind and PurgeCSS, the config file would look like:

```
const purgecss = require("@fullhuman/postcss-purgecss")({
  // Specify the paths to all of the template files in your project
  content: [
    "./assets/templates/*.html",
    // etc.
  ],

  // Include any special characters you're using in this regular expression
  defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
});

module.exports = {
  plugins: [require("tailwindcss"), require("autoprefixer"), purgecss],
};
```
We need to ensure `tailwindcss`, `autoprefixer` and `@fullhuman/postcss-purgecss` are installed via `package.json` if not already present:
```
yarn install -D @fullhuman/postcss-purgecss tailwindcss autoprefixer
```

From there, we can add the necessary tailwind imports to `app.scss` and start coding html.
```
@tailwind base;
@tailwind components;
@tailwind utilities;
```